### PR TITLE
FIXED: Invalid URLs sometimes get saved to .lastdone

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,13 @@ const getProgress = async () => {
 }
 
 const saveProgress = async (page) => {
-  const currentUrl = await page.url()
-  await fsP.writeFile('.lastdone', currentUrl, 'utf-8')
+  const currentUrl = await page.url();
+  // Only save if the URL is a valid Google Photos URL 'https://photos.google.com'
+  if (currentUrl.startsWith('https://photos.google.com')) {
+    await fsP.writeFile('.lastdone', currentUrl, 'utf-8');
+  } else {
+    console.log('Current URL does not start with https://photos.google.com, not saving progress.');
+  }
 }
 
 (async () => {


### PR DESCRIPTION
Bug: Sometimes after running for a long time, the .lastdone file would get corrupted with a direct file URL (lh.googleusercontent.com...) instead of the URL of the photo in the Google Photos UI.

Fix: When saving progress to the .lastdone file, check that the URL starts with photos.google.com before saving. This at least ensures that the app can restart from a valid location.